### PR TITLE
Pretty-print the output of `logNode`

### DIFF
--- a/src/container/__tests__/RelayContainer_hasFragmentData-test.js
+++ b/src/container/__tests__/RelayContainer_hasFragmentData-test.js
@@ -47,16 +47,6 @@ describe('RelayContainer', () => {
       store = storeData.getCachedStore();
     });
 
-    it('returns true when there are no pending queries', () => {
-      pendingQueryTracker.hasPendingQueries =
-        jest.genMockFn().mockImplementation(() => false);
-      const hasData = mockContainerInstance.hasFragmentData(
-        mockFragmentReference,
-        mockPointer
-      );
-      expect(hasData).toBe(true);
-    });
-
     it('returns true when there are pending queries, but the fragment we are ' +
        'interested in has resolved', () => {
       pendingQueryTracker.hasPendingQueries =

--- a/src/tools/RelayNetworkDebug.js
+++ b/src/tools/RelayNetworkDebug.js
@@ -72,7 +72,7 @@ const RelayNetworkDebug = {
     });
 
     const _fetch = global.fetch;
-    global.fetch = function(url, options, ...args){
+    global.fetch = function(url, options, ...args) {
       const id = queryID++;
       const name = url.split('/')[2];
       console.timeStamp(`START: fetch ${id} ${name} →`);

--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -508,6 +508,35 @@ const RelayTestUtils = {
   },
 
   /**
+   * Prints a textual representation of the query node to the console for
+   * debugging purposes.
+   *
+   * You don't want to commit any code that uses this helper, but it is
+   * useful when developing tests.
+   */
+  logNode(node) {
+    const RelayQuery = require('RelayQuery');
+    const flattenRelayQuery = require('flattenRelayQuery');
+    const printRelayQuery = require('printRelayQuery');
+
+    if (node instanceof RelayQuery.Field) {
+      // Normally can't print fields directly, so wrap it in a fake fragment.
+      node = RelayQuery.Fragment.build(
+        '__PrintableFieldWrapper',
+        '__Phony',
+        [node]
+      );
+    }
+
+    const string = JSON.stringify(
+      printRelayQuery(flattenRelayQuery(node)),
+      null,
+      2
+    );
+    console.log(string);
+  },
+
+  /**
    * Helper to write the result payload of a (root) query into a store,
    * returning created/updated ID sets. The payload is transformed before
    * writing; property keys are rewritten from application names into

--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -673,11 +673,11 @@ function createFragmentSortKey(node) {
 }
 
 /**
-  * @private
-  *
-  * Crudely transforms a query string into a "pretty" version (with
-  * whitespace) for human readability.
-  */
+ * @private
+ *
+ * Crudely transforms a query string into a "pretty" version (with
+ * whitespace) for human readability.
+ */
 function prettifyQueryString(queryText, indentSize) {
   const regexp = /[^{},]+|[{},]/g;
   let indent = '';
@@ -702,19 +702,19 @@ function prettifyQueryString(queryText, indentSize) {
 }
 
 /**
-  * @private
-  *
-  * Indents and prettifies a JSON-stringifiable input.
-  */
+ * @private
+ *
+ * Indents and prettifies a JSON-stringifiable input.
+ */
 function prettyStringify(stringifiable, indentSize) {
   return JSON.stringify(stringifiable, null, indentSize);
 }
 
 /**
-  * @private
-  *
-  * Indents (potentially multiline) `string` by `indentSize` spaces.
-  */
+ * @private
+ *
+ * Indents (potentially multiline) `string` by `indentSize` spaces.
+ */
 function indentBy(indentSize, string) {
   const indent = (new Array(indentSize + 1)).join(" ");
   return indent + string.replace(/\n/g, '\n' + indent);


### PR DESCRIPTION
Prints this:

```
Node:
  fragment __PrintableFieldWrapper on __Phony {
    feedback {
      doesViewerLike,
      id
    }
  }

Variables:
  {}
```

Instead of:

```
{
  "text": "fragment __PrintableFieldWrapper on __Phony{feedback{doesViewerLike,id}}",
  "variables": {}
}
```